### PR TITLE
Genotype arrays allow HDF5-like data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ flake8==3.7.7
 coverage==4.5.3
 coveralls==1.8.1
 setuptools-scm==3.3.3
+zarr==2.3.2

--- a/src/skallel/model/oo.py
+++ b/src/skallel/model/oo.py
@@ -12,6 +12,8 @@ class GenotypeArray(object):
     def __init__(self, data):
         """TODO"""
 
+        # TODO support hdf5-like data
+
         # check type
         if isinstance(data, np.ndarray):
             self._fn = fn_numpy
@@ -67,10 +69,23 @@ class GenotypeArray(object):
 
     def is_hom(self):
         """TODO"""
+        # TODO support allele argument
         return self._fn.genotype_array_is_hom(self.data)
+
+    # TODO is_het
+    # TODO is_call
+    # TODO to_n_ref
+    # TODO to_n_alt
+    # TODO to_allele_counts
+    # TODO to_haplotypes
+    # TODO __repr__
+    # TODO display
+    # TODO map_alleles
+    # TODO max
 
     def count_alleles(self, max_allele):
         """TODO"""
+        # TODO support subpop arg
         # TODO wrap the result as AlleleCountsArray
         return self._fn.genotype_array_count_alleles(self.data, max_allele)
 
@@ -85,11 +100,74 @@ class GenotypeArray(object):
     # TODO select_samples_by_mask
     # TODO take
     # TODO compress
-    # TODO to_allele_counts
+    # TODO concatenate
+
+
+# TODO HaplotypeArray
+# TODO n_variants
+# TODO n_haplotypes
+# TODO __getitem__
+# TODO take
+# TODO compress
+# TODO concatenate
+# TODO is_called
+# TODO is_missing
+# TODO is_ref
+# TODO is_alt
+# TODO is_call
+# TODO to_genotypes
+# TODO count_alleles
+# TODO map_alleles
+# TODO prefix_argsort
+# TODO distinct
+# TODO distinct_counts
+# TODO distinct_frequencies
+# TODO display
+# TODO __repr__
+
+
+# TODO AlleleCountsArray
+# TODO __add__
+# TODO __sub__
+# TODO n_variants
+# TODO n_alleles
+# TODO __getitem__
+# TODO compress
+# TODO take
+# TODO concatenate
+# TODO to_frequencies
+# TODO allelism
+# TODO max_allele
+# TODO is_variant
+# TODO is_non_variant
+# TODO is_segregating
+# TODO is_non_segregating
+# TODO is_singleton
+# TODO is_doubleton
+# TODO is_biallelic
+# TODO is_biallelic_01
+# TODO map_alleles
+# TODO display
+# TODO __repr__
+
+
+# TODO GenotypeAlleleCountsArray
 
 
 # TODO Callset
+# TODO __getitem__
+
+
 # TODO ContigCallset
-# TODO HaplotypeArray
-# TODO AlleleCountsArray
-# TODO GenotypeAlleleCountsArray
+# TODO __getitem__
+# TODO select_variants_by_id
+# TODO select_variants_by_position
+# TODO select_variants_by_region
+# TODO select_variants_by_index
+# TODO select_variants_by_mask
+# TODO select_samples_by_id
+# TODO select_samples_by_index
+# TODO select_samples_by_mask
+# TODO take
+# TODO compress
+# TODO concatenate?

--- a/src/skallel/model/oo.py
+++ b/src/skallel/model/oo.py
@@ -6,18 +6,29 @@ from . import fn_numpy
 from . import fn_dask
 
 
+def is_hdf5_like(x):
+    return (
+        hasattr(x, "ndim")
+        and hasattr(x, "dtype")
+        and hasattr(x, "shape")
+        and hasattr(x, "chunks")
+        and len(x.chunks) == len(x.shape) == x.ndim
+    )
+
+
 class GenotypeArray(object):
     """TODO"""
 
     def __init__(self, data):
         """TODO"""
 
-        # TODO support hdf5-like data
-
         # check type
         if isinstance(data, np.ndarray):
             self._fn = fn_numpy
         elif isinstance(data, da.Array):
+            self._fn = fn_dask
+        elif is_hdf5_like(data):
+            data = da.from_array(data, chunks=data.chunks)
             self._fn = fn_dask
         else:
             raise TypeError("TODO")

--- a/tests/test_genotype_array.py
+++ b/tests/test_genotype_array.py
@@ -2,6 +2,7 @@ import numpy as np
 import dask.array as da
 import pytest
 from numpy.testing import assert_array_equal
+import zarr
 
 
 from skallel.model.oo import GenotypeArray
@@ -23,6 +24,15 @@ def test_init():
     gt = GenotypeArray(data_dask)
     assert data_dask is gt.data
     assert data_dask is gt.values
+    assert 2 == gt.n_variants
+    assert 3 == gt.n_samples
+    assert 2 == gt.ploidy
+
+    # valid data - zarr array
+    data_zarr = zarr.array(data)
+    gt = GenotypeArray(data_zarr)
+    # expect data will get converted to a dask array
+    assert isinstance(gt.data, da.Array)
     assert 2 == gt.n_variants
     assert 3 == gt.n_samples
     assert 2 == gt.ploidy


### PR DESCRIPTION
This is a small PR to allow the `GenotypeArray` class to accept an h5py dataset or zarr array as the `data` argument. This is a convenience for the user, and gets converted internally to a dask array for processing via dask.

Also some TODO comments added as a reminder of what might be in scope for future work.