### PR TITLE
Variants dataframes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # library requirements
 numba==0.44.0
 numpy==1.16.4
-dask[array]==2.0.0
+dask[complete]==2.0.0
 pandas==0.24.2
 # test requirements
 tox==3.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 numba==0.44.0
 numpy==1.16.4
 dask[array]==2.0.0
+pandas==0.24.2
 # test requirements
 tox==3.12.1
 pytest==4.6.3

--- a/src/skallel/model/oo.py
+++ b/src/skallel/model/oo.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 import dask.array as da
 import pandas as pd
@@ -224,16 +225,20 @@ class ContigCallset(object):
         # build dataframe
         df_cols = {}
         for k in keys:
-            # load values
+            # load values into memory
             a = self.data["variants"][k][:]
             # check number of dimensions
             if a.ndim == 1:
                 df_cols[k] = a
             elif a.ndim == 2:
+                # split columns
                 for i in range(a.shape[1]):
                     df_cols["{}_{}".format(k, i + 1)] = a[:, i]
             else:
-                raise ValueError("TODO")
+                warnings.warn(
+                    "Ignoring {!r} because it has an unsupported number of "
+                    "dimensions.".format(k)
+                )
         df = pd.DataFrame(df_cols)
 
         # set index

--- a/tests/test_contig_callset.py
+++ b/tests/test_contig_callset.py
@@ -1,0 +1,156 @@
+import zarr
+import numpy as np
+from numpy.testing import assert_array_equal
+import pandas as pd
+from skallel.model.oo import ContigCallset
+
+
+def setup_callset_data_zarr():
+    data = zarr.group()
+    data.create_dataset("variants/ID", data=np.array(["RS1", "RS3", "RS9", "RS11"]))
+    data.create_dataset("variants/POS", data=np.array([3, 6, 18, 42]))
+    data.create_dataset("variants/REF", data=np.array(["A", "C", "T", "G"]))
+    data.create_dataset(
+        "variants/ALT", data=np.array([["C", ""], ["T", "G"], ["G", ""], ["CAA", "T"]])
+    )
+    data.create_dataset("variants/QUAL", data=np.array([3.4, 6.7, 18.1, 42.0]))
+    data.create_dataset(
+        "variants/FILTER_PASS", data=np.array([True, True, False, True])
+    )
+    data.create_dataset("variants/DP", data=np.array([12, 23, 34, 45]))
+    data.create_dataset(
+        "variants/AC", data=np.array([[12, 23], [34, 45], [56, 67], [78, 89]])
+    )
+    return data
+
+
+def test_init():
+
+    # test zarr data
+    data = setup_callset_data_zarr()
+
+    # instantiate
+    callset = ContigCallset(data)
+
+    # test properties
+    assert data is callset.data
+
+
+def test_variants_to_dataframe_default():
+
+    # setup
+    data = setup_callset_data_zarr()
+    callset = ContigCallset(data)
+
+    # construct dataframe
+    df = callset.variants_to_dataframe()
+    assert isinstance(df, pd.DataFrame)
+
+    # check default column ordering - expect VCF fixed fields first if present,
+    # then other fields ordered alphabetically
+    assert [
+        "ID",
+        "REF",
+        "ALT_1",
+        "ALT_2",
+        "QUAL",
+        "FILTER_PASS",
+        "AC_1",
+        "AC_2",
+        "DP",
+    ] == df.columns.tolist()
+
+    # check POS used as index
+    assert "POS" == df.index.name
+
+    # check data
+    assert_array_equal(data["variants/POS"][:], df.index.values)
+    assert_array_equal(data["variants/ID"][:], df["ID"].values)
+    assert_array_equal(data["variants/REF"][:], df["REF"].values)
+    assert_array_equal(data["variants/ALT"][:, 0], df["ALT_1"].values)
+    assert_array_equal(data["variants/ALT"][:, 1], df["ALT_2"].values)
+    assert_array_equal(data["variants/QUAL"][:], df["QUAL"].values)
+    assert_array_equal(data["variants/FILTER_PASS"][:], df["FILTER_PASS"].values)
+    assert_array_equal(data["variants/AC"][:, 0], df["AC_1"].values)
+    assert_array_equal(data["variants/AC"][:, 1], df["AC_2"].values)
+    assert_array_equal(data["variants/DP"][:], df["DP"].values)
+
+
+def test_variants_to_dataframe_noindex():
+
+    # setup
+    data = setup_callset_data_zarr()
+    callset = ContigCallset(data)
+
+    # construct dataframe
+    df = callset.variants_to_dataframe(index=None)
+    assert isinstance(df, pd.DataFrame)
+
+    assert [
+        "POS",
+        "ID",
+        "REF",
+        "ALT_1",
+        "ALT_2",
+        "QUAL",
+        "FILTER_PASS",
+        "AC_1",
+        "AC_2",
+        "DP",
+    ] == df.columns.tolist()
+
+    # check POS used as index
+    assert None is df.index.name
+
+    # check data
+    assert_array_equal(data["variants/POS"][:], df["POS"].values)
+
+
+def test_variants_to_dataframe_columns():
+
+    # setup
+    data = setup_callset_data_zarr()
+    callset = ContigCallset(data)
+
+    # construct dataframe
+    df = callset.variants_to_dataframe(columns=["REF", "POS", "DP", "AC"])
+    assert isinstance(df, pd.DataFrame)
+
+    # check default column ordering - expect VCF fixed fields first if present,
+    # then other fields ordered alphabetically
+    assert ["REF", "DP", "AC_1", "AC_2"] == df.columns.tolist()
+
+    # check POS used as index
+    assert "POS" == df.index.name
+
+    # check data
+    assert_array_equal(data["variants/POS"][:], df.index.values)
+    assert_array_equal(data["variants/REF"][:], df["REF"].values)
+    assert_array_equal(data["variants/AC"][:, 0], df["AC_1"].values)
+    assert_array_equal(data["variants/AC"][:, 1], df["AC_2"].values)
+    assert_array_equal(data["variants/DP"][:], df["DP"].values)
+
+
+def test_variants_to_dataframe_columns_noindex():
+
+    # setup
+    data = setup_callset_data_zarr()
+    callset = ContigCallset(data)
+
+    # construct dataframe
+    df = callset.variants_to_dataframe(columns=["REF", "POS", "DP", "AC"], index=None)
+    assert isinstance(df, pd.DataFrame)
+
+    # check default column ordering - expect VCF fixed fields first if present,
+    # then other fields ordered alphabetically
+    assert ["REF", "POS", "DP", "AC_1", "AC_2"] == df.columns.tolist()
+
+    # check POS used as index
+    assert None is df.index.name
+
+    # check data
+    assert_array_equal(data["variants/POS"][:], df["POS"].values)
+    assert_array_equal(data["variants/REF"][:], df["REF"].values)
+    assert_array_equal(data["variants/AC"][:, 0], df["AC_1"].values)
+    assert_array_equal(data["variants/AC"][:, 1], df["AC_2"].values)
+    assert_array_equal(data["variants/DP"][:], df["DP"].values)

--- a/tests/test_contig_callset.py
+++ b/tests/test_contig_callset.py
@@ -44,38 +44,88 @@ def test_variants_to_dataframe_default():
     data = setup_callset_data_zarr()
     callset = ContigCallset(data)
 
-    # construct dataframe
-    df = callset.variants_to_dataframe()
-    assert isinstance(df, pd.DataFrame)
+    # construct dataframes
+    pdf = callset.variants_to_dataframe()
+    ddf = callset.variants_to_dask_dataframe()
 
-    # check default column ordering - expect VCF fixed fields first if present,
-    # then other fields ordered alphabetically
-    assert [
-        "ID",
-        "REF",
-        "ALT_1",
-        "ALT_2",
-        "QUAL",
-        "FILTER_PASS",
-        "AC_1",
-        "AC_2",
-        "DP",
-    ] == df.columns.tolist()
+    # check return types
+    assert isinstance(pdf, pd.DataFrame)
+    assert isinstance(ddf, dd.DataFrame)
 
-    # check POS used as index
-    assert "POS" == df.index.name
+    for df in pdf, ddf:
 
-    # check data
-    assert_array_equal(data["variants/POS"][:], df.index.values)
-    assert_array_equal(data["variants/ID"][:], df["ID"].values)
-    assert_array_equal(data["variants/REF"][:], df["REF"].values)
-    assert_array_equal(data["variants/ALT"][:, 0], df["ALT_1"].values)
-    assert_array_equal(data["variants/ALT"][:, 1], df["ALT_2"].values)
-    assert_array_equal(data["variants/QUAL"][:], df["QUAL"].values)
-    assert_array_equal(data["variants/FILTER_PASS"][:], df["FILTER_PASS"].values)
-    assert_array_equal(data["variants/AC"][:, 0], df["AC_1"].values)
-    assert_array_equal(data["variants/AC"][:, 1], df["AC_2"].values)
-    assert_array_equal(data["variants/DP"][:], df["DP"].values)
+        # check default column ordering - expect VCF fixed fields first if present,
+        # then other fields ordered alphabetically
+        expected_cols = [
+            "ID",
+            "REF",
+            "ALT_1",
+            "ALT_2",
+            "QUAL",
+            "FILTER_PASS",
+            "AC_1",
+            "AC_2",
+            "DP",
+        ]
+        assert expected_cols == df.columns.tolist()
+
+        # check POS used as index
+        assert "POS" == df.index.name
+
+        # check data
+        assert_array_equal(data["variants/POS"][:], np.asarray(df.index))
+        assert_array_equal(data["variants/ID"][:], np.asarray(df["ID"]))
+        assert_array_equal(data["variants/REF"][:], np.asarray(df["REF"]))
+        assert_array_equal(data["variants/ALT"][:, 0], np.asarray(df["ALT_1"]))
+        assert_array_equal(data["variants/ALT"][:, 1], np.asarray(df["ALT_2"]))
+        assert_array_equal(data["variants/QUAL"][:], np.asarray(df["QUAL"]))
+        assert_array_equal(
+            data["variants/FILTER_PASS"][:], np.asarray(df["FILTER_PASS"])
+        )
+        assert_array_equal(data["variants/AC"][:, 0], np.asarray(df["AC_1"]))
+        assert_array_equal(data["variants/AC"][:, 1], np.asarray(df["AC_2"]))
+        assert_array_equal(data["variants/DP"][:], np.asarray(df["DP"]))
+
+
+def test_variants_to_dataframe_index():
+
+    # setup
+    data = setup_callset_data_zarr()
+    callset = ContigCallset(data)
+
+    # construct dataframes
+    pdf = callset.variants_to_dataframe(index="ID")
+    ddf = callset.variants_to_dask_dataframe(index="ID")
+
+    for df in pdf, ddf:
+
+        # check default column ordering - expect VCF fixed fields first if present,
+        # then other fields ordered alphabetically
+        expected_cols = [
+            "POS",
+            "REF",
+            "ALT_1",
+            "ALT_2",
+            "QUAL",
+            "FILTER_PASS",
+            "AC_1",
+            "AC_2",
+            "DP",
+        ]
+        assert expected_cols == df.columns.tolist()
+
+        # check ID used as index
+        assert "ID" == df.index.name
+
+    # N.B., different behaviour here between pandas and dask, because dask forces
+    # the dataframe to be sorted by the index, whereas pandas does not.
+
+    assert_array_equal(data["variants/POS"][:], np.asarray(pdf["POS"]))
+    assert_array_equal(data["variants/ID"][:], np.asarray(pdf.index))
+
+    pdf_sorted = pdf.sort_index()
+    assert_array_equal(np.asarray(pdf_sorted["POS"]), np.asarray(ddf["POS"]))
+    assert_array_equal(np.asarray(pdf_sorted.index), np.asarray(ddf.index))
 
 
 def test_variants_to_dataframe_noindex():
@@ -84,28 +134,31 @@ def test_variants_to_dataframe_noindex():
     data = setup_callset_data_zarr()
     callset = ContigCallset(data)
 
-    # construct dataframe
-    df = callset.variants_to_dataframe(index=None)
-    assert isinstance(df, pd.DataFrame)
+    # construct dataframes
+    pdf = callset.variants_to_dataframe(index=None)
+    ddf = callset.variants_to_dask_dataframe(index=None)
 
-    assert [
-        "POS",
-        "ID",
-        "REF",
-        "ALT_1",
-        "ALT_2",
-        "QUAL",
-        "FILTER_PASS",
-        "AC_1",
-        "AC_2",
-        "DP",
-    ] == df.columns.tolist()
+    for df in pdf, ddf:
 
-    # check POS used as index
-    assert None is df.index.name
+        expected_cols = [
+            "POS",
+            "ID",
+            "REF",
+            "ALT_1",
+            "ALT_2",
+            "QUAL",
+            "FILTER_PASS",
+            "AC_1",
+            "AC_2",
+            "DP",
+        ]
+        assert expected_cols == df.columns.tolist()
 
-    # check data
-    assert_array_equal(data["variants/POS"][:], df["POS"].values)
+        # check POS used as index
+        assert None is df.index.name
+
+        # check data
+        assert_array_equal(data["variants/POS"][:], np.asarray(df["POS"]))
 
 
 def test_variants_to_dataframe_columns():
@@ -114,23 +167,25 @@ def test_variants_to_dataframe_columns():
     data = setup_callset_data_zarr()
     callset = ContigCallset(data)
 
-    # construct dataframe
-    df = callset.variants_to_dataframe(columns=["REF", "POS", "DP", "AC"])
-    assert isinstance(df, pd.DataFrame)
+    # construct dataframes
+    cols = ["REF", "POS", "DP", "AC"]
+    pdf = callset.variants_to_dataframe(columns=cols)
+    ddf = callset.variants_to_dask_dataframe(columns=cols)
 
-    # check default column ordering - expect VCF fixed fields first if present,
-    # then other fields ordered alphabetically
-    assert ["REF", "DP", "AC_1", "AC_2"] == df.columns.tolist()
+    for df in pdf, ddf:
 
-    # check POS used as index
-    assert "POS" == df.index.name
+        # check column ordering, should be as requested
+        assert ["REF", "DP", "AC_1", "AC_2"] == df.columns.tolist()
 
-    # check data
-    assert_array_equal(data["variants/POS"][:], df.index.values)
-    assert_array_equal(data["variants/REF"][:], df["REF"].values)
-    assert_array_equal(data["variants/AC"][:, 0], df["AC_1"].values)
-    assert_array_equal(data["variants/AC"][:, 1], df["AC_2"].values)
-    assert_array_equal(data["variants/DP"][:], df["DP"].values)
+        # check POS used as index
+        assert "POS" == df.index.name
+
+        # check data
+        assert_array_equal(data["variants/POS"][:], np.asarray(df.index))
+        assert_array_equal(data["variants/REF"][:], np.asarray(df["REF"]))
+        assert_array_equal(data["variants/AC"][:, 0], np.asarray(df["AC_1"]))
+        assert_array_equal(data["variants/AC"][:, 1], np.asarray(df["AC_2"]))
+        assert_array_equal(data["variants/DP"][:], np.asarray(df["DP"]))
 
 
 def test_variants_to_dataframe_columns_noindex():
@@ -139,23 +194,25 @@ def test_variants_to_dataframe_columns_noindex():
     data = setup_callset_data_zarr()
     callset = ContigCallset(data)
 
-    # construct dataframe
-    df = callset.variants_to_dataframe(columns=["REF", "POS", "DP", "AC"], index=None)
-    assert isinstance(df, pd.DataFrame)
+    # construct dataframes
+    cols = ["REF", "POS", "DP", "AC"]
+    pdf = callset.variants_to_dataframe(columns=cols, index=None)
+    ddf = callset.variants_to_dask_dataframe(columns=cols, index=None)
 
-    # check default column ordering - expect VCF fixed fields first if present,
-    # then other fields ordered alphabetically
-    assert ["REF", "POS", "DP", "AC_1", "AC_2"] == df.columns.tolist()
+    for df in pdf, ddf:
 
-    # check POS used as index
-    assert None is df.index.name
+        # check column ordering, should be as requested
+        assert ["REF", "POS", "DP", "AC_1", "AC_2"] == df.columns.tolist()
 
-    # check data
-    assert_array_equal(data["variants/POS"][:], df["POS"].values)
-    assert_array_equal(data["variants/REF"][:], df["REF"].values)
-    assert_array_equal(data["variants/AC"][:, 0], df["AC_1"].values)
-    assert_array_equal(data["variants/AC"][:, 1], df["AC_2"].values)
-    assert_array_equal(data["variants/DP"][:], df["DP"].values)
+        # check POS not used as index
+        assert None is df.index.name
+
+        # check data
+        assert_array_equal(data["variants/POS"][:], np.asarray(df["POS"]))
+        assert_array_equal(data["variants/REF"][:], np.asarray(df["REF"]))
+        assert_array_equal(data["variants/AC"][:, 0], np.asarray(df["AC_1"]))
+        assert_array_equal(data["variants/AC"][:, 1], np.asarray(df["AC_2"]))
+        assert_array_equal(data["variants/DP"][:], np.asarray(df["DP"]))
 
 
 def test_variants_to_dataframe_exceptions():
@@ -167,46 +224,12 @@ def test_variants_to_dataframe_exceptions():
     # field not present in data
     with pytest.raises(ValueError):
         callset.variants_to_dataframe(columns=["foo"])
+    with pytest.raises(ValueError):
+        callset.variants_to_dask_dataframe(columns=["foo"])
 
     # array has too many dimensions
-    data.create_dataset("variants/bar", data=np.arange(1000).reshape(10, 10, 10))
+    data.create_dataset("variants/bar", data=np.arange(1000).reshape((10, 10, 10)))
     with pytest.warns(UserWarning):
         callset.variants_to_dataframe()
-
-
-def test_variants_to_dask_dataframe_default():
-
-    # setup
-    data = setup_callset_data_zarr()
-    callset = ContigCallset(data)
-
-    # construct dataframe
-    df = callset.variants_to_dask_dataframe()
-    assert isinstance(df, dd.DataFrame)
-
-    # check default column ordering - expect VCF fixed fields first if present,
-    # then other fields ordered alphabetically
-    assert [
-        "POS",
-        "ID",
-        "REF",
-        "ALT_1",
-        "ALT_2",
-        "QUAL",
-        "FILTER_PASS",
-        "AC_1",
-        "AC_2",
-        "DP",
-    ] == df.columns.tolist()
-
-    # check data
-    assert_array_equal(data["variants/POS"][:], df["POS"].compute())
-    assert_array_equal(data["variants/ID"][:], df["ID"].compute())
-    assert_array_equal(data["variants/REF"][:], df["REF"].compute())
-    assert_array_equal(data["variants/ALT"][:, 0], df["ALT_1"].compute())
-    assert_array_equal(data["variants/ALT"][:, 1], df["ALT_2"].compute())
-    assert_array_equal(data["variants/QUAL"][:], df["QUAL"].compute())
-    assert_array_equal(data["variants/FILTER_PASS"][:], df["FILTER_PASS"].compute())
-    assert_array_equal(data["variants/AC"][:, 0], df["AC_1"].compute())
-    assert_array_equal(data["variants/AC"][:, 1], df["AC_2"].compute())
-    assert_array_equal(data["variants/DP"][:], df["DP"].compute())
+    with pytest.warns(UserWarning):
+        callset.variants_to_dask_dataframe()

--- a/tests/test_contig_callset.py
+++ b/tests/test_contig_callset.py
@@ -2,6 +2,7 @@ import zarr
 import numpy as np
 from numpy.testing import assert_array_equal
 import pandas as pd
+import pytest
 from skallel.model.oo import ContigCallset
 
 
@@ -154,3 +155,19 @@ def test_variants_to_dataframe_columns_noindex():
     assert_array_equal(data["variants/AC"][:, 0], df["AC_1"].values)
     assert_array_equal(data["variants/AC"][:, 1], df["AC_2"].values)
     assert_array_equal(data["variants/DP"][:], df["DP"].values)
+
+
+def test_variants_to_dataframe_exceptions():
+
+    # setup
+    data = setup_callset_data_zarr()
+    callset = ContigCallset(data)
+
+    # field not present in data
+    with pytest.raises(ValueError):
+        callset.variants_to_dataframe(columns=["foo"])
+
+    # array has too many dimensions
+    data.create_dataset("variants/bar", data=np.arange(1000).reshape(10, 10, 10))
+    with pytest.warns(UserWarning):
+        callset.variants_to_dataframe()


### PR DESCRIPTION
This PR adds the beginnings of a `ContigCallset` class, with methods for building pandas and dask dataframes from variants arrays.